### PR TITLE
use npm to build with webpack prior to run/debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.idea/runConfigurations/index_html.xml
+++ b/.idea/runConfigurations/index_html.xml
@@ -1,7 +1,26 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="index.html" type="JavascriptDebugType" factoryName="JavaScript Debug" nameIsGenerated="true" uri="http://localhost:63342/debugging-webpack/index.html">
-    <mapping url="http://localhost:63342/debugging-webpack/build" local-file="$PROJECT_DIR$/build" />
     <mapping url="webpack:///." local-file="$PROJECT_DIR$" />
-    <method />
+    <mapping url="http://localhost:63342/debugging-webpack/build" local-file="$PROJECT_DIR$/build" />
+    <method>
+      <option name="NpmBeforeRunTask" enabled="true">
+        <package-json value="$PROJECT_DIR$/package.json" />
+        <command value="run" />
+        <scripts>
+          <script value="clean" />
+        </scripts>
+        <node-interpreter value="project" />
+        <envs />
+      </option>
+      <option name="NpmBeforeRunTask" enabled="true">
+        <package-json value="$PROJECT_DIR$/package.json" />
+        <command value="run" />
+        <scripts>
+          <script value="build" />
+        </scripts>
+        <node-interpreter value="project" />
+        <envs />
+      </option>
+    </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/index_html.xml
+++ b/.idea/runConfigurations/index_html.xml
@@ -7,15 +7,6 @@
         <package-json value="$PROJECT_DIR$/package.json" />
         <command value="run" />
         <scripts>
-          <script value="clean" />
-        </scripts>
-        <node-interpreter value="project" />
-        <envs />
-      </option>
-      <option name="NpmBeforeRunTask" enabled="true">
-        <package-json value="$PROJECT_DIR$/package.json" />
-        <command value="run" />
-        <scripts>
           <script value="build" />
         </scripts>
         <node-interpreter value="project" />

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "debugging-webpack",
+  "version": "1.0.0",
+  "description": "",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nwbt/debugging-webpack.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/nwbt/debugging-webpack/issues"
+  },
+  "homepage": "https://github.com/nwbt/debugging-webpack#readme",
+  "devDependencies": {
+    "webpack": "^2.2.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "debugging-webpack",
   "version": "1.0.0",
   "description": "",
-  "main": "main.js",
+  "main": "./main.js",
   "scripts": {
-    "build": "webpack",
+    "build": "webpack --config webpack.config.js",
     "clean": "rm -fr ./build"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,20 +5,8 @@
   "main": "main.js",
   "scripts": {
     "build": "webpack",
-    "clean": "rm -fr ./build",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "clean": "rm -fr ./build"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nwbt/debugging-webpack.git"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/nwbt/debugging-webpack/issues"
-  },
-  "homepage": "https://github.com/nwbt/debugging-webpack#readme",
   "devDependencies": {
     "webpack": "^2.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "main.js",
   "scripts": {
+    "build": "webpack",
+    "clean": "rm -fr ./build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,8 @@
+let path = require('path');
 module.exports = {
     entry: "./main.js",
     output: {
-        path: __dirname + "/build",
+        path: path.resolve(__dirname, "build"),
         filename: "bundle.js"
     },
     devtool: "source-map"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-let path = require('path');
+var path = require('path');
 module.exports = {
     entry: "./main.js",
     output: {


### PR DESCRIPTION
added npm config for webpack which includes npm run build & clean commands to build 'build' directory during the default run/debug configuration. Simple changes with the hope this will help someone understand the interaction between webstorm, npm, and webpack a little better.